### PR TITLE
Suppress the default "AI:" and "Human:" prompts in few-shot mode

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -22,6 +22,12 @@ var sessionMaxLength = 1024;
 
 var totalElapsed, nRequests;
 
+const mode = {
+  CHATBOT: 1,
+  FEW_SHOT: 2,
+};
+let current_mode = mode.CHATBOT;
+
 function openSession() {
   ws = new WebSocket(`ws://${location.host}/api/v2/generate`);
   ws.onopen = () => {
@@ -59,10 +65,12 @@ function isWaitingForInputs() {
 
 function sendReplica() {
   if (isWaitingForInputs()) {
+    const answer_prompt = (current_mode === mode.CHATBOT) ? 'AI:' : '';
     $('.human-replica:last').text($('.human-replica:last textarea').val());
     $('.dialogue').append($(
       '<p class="ai-replica">' +
-        '<span class="text">AI:</span><span class="loading-animation"></span>' +
+        '<span class="text">' + answer_prompt + '</span>' +
+        '<span class="loading-animation"></span>' +
         '<span class="speed" style="display: none;"></span>' +
         '<span class="suggest-join" style="display: none;">' +
           'This speed is slower than expected due to a high load. You can increase Petals capacity by ' +
@@ -147,8 +155,9 @@ function receiveReplica(inputs) {
         }
       }
     } else {
+      const html = (current_mode === mode.CHATBOT) ? textareaHtml : textareaHtml.replace("Human:", "");
       $('.loading-animation, .speed, .suggest-join').remove();
-      $('.dialogue').append($(textareaHtml));
+      $('.dialogue').append($(html));
       upgradeTextArea();
     }
   };
@@ -226,6 +235,7 @@ $(() => {
 
   $('.show-few-shot').click(e => {
     e.preventDefault();
+    current_mode = mode.FEW_SHOT;
 
     if (resetDialogue()) {
       const textarea = $('.human-replica textarea');


### PR DESCRIPTION
Especially the "AI:" prompt formally couldn't be deleted, and threw the AI off sometimes.

Example:

Before:

<img width="813" alt="Screenshot 2023-01-19 at 14 54 57" src="https://user-images.githubusercontent.com/140654/213464111-4ea6fe60-8e3d-457f-b872-77f36061afb1.png">

after:

<img width="850" alt="Screenshot 2023-01-19 at 14 55 06" src="https://user-images.githubusercontent.com/140654/213464179-d1a2821a-28b6-4ebe-ab0f-e5b6085e520a.png">
