### PR TITLE
Enable Cross Origin Resource Sharing for the api

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import hivemind
 import torch
 from flask import Flask
+from flask_cors import CORS
 from flask_sock import Sock
 from transformers import BloomTokenizerFast
 
@@ -24,6 +25,7 @@ for model_name in config.MODEL_NAMES:
 
 logger.info("Starting Flask app")
 app = Flask(__name__)
+CORS(app)
 app.config['SOCK_SERVER_OPTIONS'] = {'ping_interval': 25}
 sock = Sock(app)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/bigscience-workshop/petals
 Flask
 flask-sock
+flask-cors
 gunicorn


### PR DESCRIPTION
This enables Cross origin resource sharing for the api. This makes it easier to use the api from web-apps that are hosted at different domain.