### PR TITLE
Security upgrade setuptools from 39.0.1 to 65.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask
 flask-sock
 flask-cors
 gunicorn
+setuptools>=65.5.1


### PR DESCRIPTION
#### Changes included in this PR

- Changes to the following files to upgrade the vulnerable dependencies to a fixed version: - requirements.txt



#### Vulnerabilities that will be fixed





##### By pinning:
Severity                   | Priority Score (*)                   | Issue                   | Upgrade                   | Breaking Change                   | Exploit Maturity
:-------------------------:|-------------------------|:-------------------------|:-------------------------|:-------------------------|:-------------------------
![medium severity](https://res.cloudinary.com/snyk/image/upload/w_20,h_20/v1561977819/icon/m.png "medium severity")  |  **509/1000**  <br/> **Why?** Has a fix available, CVSS 5.9  | Regular Expression Denial of Service (ReDoS) <br/>[SNYK-PYTHON-SETUPTOOLS-3180412](https://snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3180412) |  `setuptools:` <br> `39.0.1 -> 65.5.1` <br>  |  No  | No Known Exploit