### PR TITLE
Fix for decoding unicode characters

### DIFF
--- a/websocket_api.py
+++ b/websocket_api.py
@@ -71,7 +71,7 @@ def ws_api_generate(ws):
                             if combined.endswith(seq):
                                 stop = True
                                 session.last_token_id = cont_token
-                    if not stop and outputs.find(u'\ufffd') > -1:
+                    if not stop and outputs[-10:].find(u'\ufffd') > -1:
                         # If there's a replacement character, keep getting more tokens
                         # until we can decode properly
                         delta_q = delta_q + delta

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -3,6 +3,7 @@ from traceback import format_exc
 
 import flask_sock
 import hivemind
+import torch
 
 import config
 from app import sock, models
@@ -46,6 +47,8 @@ def ws_api_generate(ws):
                         "extra_stop_sequences require stop_sequence length to be exactly 1 token"
 
                 all_outputs = ''
+                
+                delta_q = []
                 stop = False
                 while not stop:
                     outputs = model.generate(
@@ -58,21 +61,27 @@ def ws_api_generate(ws):
                         max_new_tokens=request.get("max_new_tokens"),
                         session=session,
                     )
-                    outputs = safe_decode(tokenizer, outputs[0, n_input_tokens:])
-                    all_outputs += outputs
-
-                    stop = stop_sequence is None or all_outputs.endswith(stop_sequence)
-                    if extra_stop_sequences is not None:
-                        for seq in extra_stop_sequences:
-                            if all_outputs.endswith(seq):
-                                stop = True
-                                session.last_token_id = cont_token
-
+                    delta = outputs[0, n_input_tokens:].tolist()
+                    outputs = safe_decode(tokenizer, torch.Tensor(delta_q + delta))
                     inputs = None  # Inputs are passed only for the 1st token of the bot's response
-                    n_input_tokens = 0
+                    n_input_tokens = 0 
+                    if outputs.find(u'\ufffd') > -1 and len(delta_q) < 50:
+                        # If there's a replacement character, keep getting more tokens
+                        # until we can decode properly
+                        delta_q = delta_q + delta
+                        logger.info(f"ws.generate.step(), get next: all_outputs={repr(all_outputs + outputs)}, stop={stop}")
+                    else:
+                        all_outputs += outputs
+                        delta_q = []
+                        stop = stop_sequence is None or all_outputs.endswith(stop_sequence)
+                        if extra_stop_sequences is not None:
+                            for seq in extra_stop_sequences:
+                                if all_outputs.endswith(seq):
+                                    stop = True
+                                    session.last_token_id = cont_token
 
-                    logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
-                    ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop}))
+                        logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
+                        ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop}))
     except flask_sock.ConnectionClosed:
         pass
     except Exception:

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -75,9 +75,9 @@ def ws_api_generate(ws):
                         # If there's a replacement character, keep getting more tokens
                         # until we can decode properly
                         delta_q = delta_q + delta
-                        logger.info(f"ws.generate.step(), get next: all_outputs={repr(combined)}, stop={stop}")
+                        logger.info(f"ws.generate.append_retry(), all_outputs={repr(combined)}")
                     else:
-                        all_outputs += outputs
+                        all_outputs = combined
                         delta_q = []
                         logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
                         ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop}))

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -71,7 +71,7 @@ def ws_api_generate(ws):
                             if combined.endswith(seq):
                                 stop = True
                                 session.last_token_id = cont_token
-                    if outputs.find(u'\ufffd') > -1:
+                    if not stop and outputs.find(u'\ufffd') > -1:
                         # If there's a replacement character, keep getting more tokens
                         # until we can decode properly
                         delta_q = delta_q + delta


### PR DESCRIPTION
Fix for #30 

Before, Unicode characters would not decode properly. Now, if a replacement character of '\ufffd' is found in the decoded output, it will continue requesting more completion tokens until it is able to decode without a replacement character / decode error.
