### PR TITLE
Use token count for speed calc

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -62,7 +62,7 @@ const initialSessionLength = 512;
 var sessionLength = initialSessionLength;
 var connFailureBefore = false;
 
-var totalElapsed, nRequests;
+var totalElapsed, nRequests, tokenCount;
 
 const Regime = {
   CHATBOT: 1,
@@ -156,6 +156,7 @@ function sendReplica() {
 
   totalElapsed = 0;
   nRequests = 0;
+  tokenCount = 0;
   receiveReplica(inputs);
 }
 
@@ -181,7 +182,8 @@ function receiveReplica(inputs) {
 
     if (lastMessageTime != null) {
       totalElapsed += performance.now() - lastMessageTime;
-      nRequests++;
+      tokenCount += response.token_count;
+      nRequests ++;
     }
     lastMessageTime = performance.now();
 
@@ -196,8 +198,8 @@ function receiveReplica(inputs) {
     lastReplica.text(newText);
 
     if (!response.stop && !stop) {
-      if (nRequests >= 1) {
-        const speed = nRequests / (totalElapsed / 1000);
+      if (tokenCount >= 1) {
+        const speed = tokenCount / (totalElapsed / 1000);
         $('.speed')
           .text(`Speed: ${speed.toFixed(1)} tokens/sec`)
           .show();

--- a/static/chat.js
+++ b/static/chat.js
@@ -54,7 +54,7 @@ const initialSessionLength = 512;
 var sessionLength = initialSessionLength;
 var connFailureBefore = false;
 
-var totalElapsed, nRequests, tokenCount;
+var totalElapsed, tokenCount;
 
 const Regime = {
   CHATBOT: 1,
@@ -147,7 +147,6 @@ function sendReplica() {
   position = replicaDivs.length;
 
   totalElapsed = 0;
-  nRequests = 0;
   tokenCount = 0;
   receiveReplica(inputs);
 }
@@ -175,7 +174,6 @@ function receiveReplica(inputs) {
     if (lastMessageTime != null) {
       totalElapsed += performance.now() - lastMessageTime;
       tokenCount += response.token_count;
-      nRequests++;
     }
     lastMessageTime = performance.now();
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -183,7 +183,7 @@ function receiveReplica(inputs) {
     if (lastMessageTime != null) {
       totalElapsed += performance.now() - lastMessageTime;
       tokenCount += response.token_count;
-      nRequests ++;
+      nRequests++;
     }
     lastMessageTime = performance.now();
 

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -71,7 +71,7 @@ def ws_api_generate(ws):
                             if combined.endswith(seq):
                                 stop = True
                                 session.last_token_id = cont_token
-                    if not stop and outputs.find(u'\ufffd') > -1:
+                    if not stop and outputs[-10:].find(u'\ufffd') > -1:
                         # If there's a replacement character, keep getting more tokens
                         # until we can decode properly
                         delta_q = delta_q + delta

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -48,8 +48,10 @@ def ws_api_generate(ws):
 
                 all_outputs = ''
                 delta_q = []
+                steps=0
                 stop = False
                 while not stop:
+                    steps += 1
                     outputs = model.generate(
                         inputs=inputs,
                         do_sample=request.get("do_sample", False),
@@ -80,7 +82,7 @@ def ws_api_generate(ws):
                         all_outputs = combined
                         delta_q = []
                         logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
-                        ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop}))
+                        ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop, "steps": steps}))
     except flask_sock.ConnectionClosed:
         pass
     except Exception:

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -3,6 +3,7 @@ from traceback import format_exc
 
 import flask_sock
 import hivemind
+import torch
 
 import config
 from app import sock, models
@@ -46,6 +47,8 @@ def ws_api_generate(ws):
                         "extra_stop_sequences require stop_sequence length to be exactly 1 token"
 
                 all_outputs = ''
+                
+                delta_q = []
                 stop = False
                 while not stop:
                     outputs = model.generate(
@@ -58,21 +61,27 @@ def ws_api_generate(ws):
                         max_new_tokens=request.get("max_new_tokens"),
                         session=session,
                     )
-                    outputs = safe_decode(tokenizer, outputs[0, n_input_tokens:])
-                    all_outputs += outputs
-
-                    stop = stop_sequence is None or all_outputs.endswith(stop_sequence)
-                    if extra_stop_sequences is not None:
-                        for seq in extra_stop_sequences:
-                            if all_outputs.endswith(seq):
-                                stop = True
-                                session.last_token_id = cont_token
-
+                    delta = outputs[0, n_input_tokens:].tolist()
+                    outputs = safe_decode(tokenizer, torch.Tensor(delta_q + delta))
                     inputs = None  # Inputs are passed only for the 1st token of the bot's response
-                    n_input_tokens = 0
+                    n_input_tokens = 0 
+                    if outputs.find(u'\ufffd') > -1 and len(delta_q) < 50:
+                        # If there's a replacement character, keep getting more tokens
+                        # until we can decode properly
+                        delta_q = delta_q + delta
+                        logger.info(f"ws.generate.step(), get next: all_outputs={repr(all_outputs + outputs)}, stop={stop}")
+                    else:
+                        all_outputs += outputs
+                        delta_q = []
+                        stop = stop_sequence is None or all_outputs.endswith(stop_sequence)
+                        if extra_stop_sequences is not None:
+                            for seq in extra_stop_sequences:
+                                if all_outputs.endswith(seq):
+                                    stop = True
+                                    session.last_token_id = cont_token
 
-                    logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
-                    ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop}))
+                        logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
+                        ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop}))
     except flask_sock.ConnectionClosed:
         pass
     except Exception:

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -80,10 +80,11 @@ def ws_api_generate(ws):
                         logger.info(f"ws.generate.append_retry(), all_outputs={repr(combined)}")
                     else:
                         all_outputs = combined
-                        token_count = len([delta_q + delta])
+                        token_count = len(delta_q + delta)
                         delta_q = []
                         logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
                         ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop, "steps": steps, "token_count": token_count}))
+                        steps=0
     except flask_sock.ConnectionClosed:
         pass
     except Exception:

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -48,10 +48,8 @@ def ws_api_generate(ws):
 
                 all_outputs = ''
                 delta_q = []
-                steps = 0
                 stop = False
                 while not stop:
-                    steps += 1
                     outputs = model.generate(
                         inputs=inputs,
                         do_sample=request.get("do_sample", False),
@@ -83,8 +81,7 @@ def ws_api_generate(ws):
                         token_count = len(delta_q + delta)
                         delta_q = []
                         logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
-                        ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop, "steps": steps, "token_count": token_count}))
-                        steps = 0
+                        ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop, "token_count": token_count}))
     except flask_sock.ConnectionClosed:
         pass
     except Exception:

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -48,7 +48,7 @@ def ws_api_generate(ws):
 
                 all_outputs = ''
                 delta_q = []
-                steps=0
+                steps = 0
                 stop = False
                 while not stop:
                     steps += 1
@@ -84,7 +84,7 @@ def ws_api_generate(ws):
                         delta_q = []
                         logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
                         ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop, "steps": steps, "token_count": token_count}))
-                        steps=0
+                        steps = 0
     except flask_sock.ConnectionClosed:
         pass
     except Exception:

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -75,9 +75,9 @@ def ws_api_generate(ws):
                         # If there's a replacement character, keep getting more tokens
                         # until we can decode properly
                         delta_q = delta_q + delta
-                        logger.info(f"ws.generate.step(), get next: all_outputs={repr(combined)}, stop={stop}")
+                        logger.info(f"ws.generate.append_retry(), all_outputs={repr(combined)}")
                     else:
-                        all_outputs += outputs
+                        all_outputs = combined
                         delta_q = []
                         logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
                         ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop}))

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -71,7 +71,7 @@ def ws_api_generate(ws):
                             if combined.endswith(seq):
                                 stop = True
                                 session.last_token_id = cont_token
-                    if outputs.find(u'\ufffd') > -1:
+                    if not stop and outputs.find(u'\ufffd') > -1:
                         # If there's a replacement character, keep getting more tokens
                         # until we can decode properly
                         delta_q = delta_q + delta

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -80,9 +80,10 @@ def ws_api_generate(ws):
                         logger.info(f"ws.generate.append_retry(), all_outputs={repr(combined)}")
                     else:
                         all_outputs = combined
+                        token_count = len([delta_q + delta])
                         delta_q = []
                         logger.info(f"ws.generate.step(), all_outputs={repr(all_outputs)}, stop={stop}")
-                        ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop, "steps": steps}))
+                        ws.send(json.dumps({"ok": True, "outputs": outputs, "stop": stop, "steps": steps, "token_count": token_count}))
     except flask_sock.ConnectionClosed:
         pass
     except Exception:


### PR DESCRIPTION
Added `token_count` of delta for each respose, since if max_new_tokens > 1 steps would be be more difficult to use for speed calculation.

Fixes #33.