### PR TITLE
Refactor to define models in one place

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install -r requirements.txt
 flask run --host=0.0.0.0 --port=5000
 ```
 
-🦙 **Want to serve Llama 2?** Request access to its weights at the ♾️ [Meta AI website](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and 🤗 [Model Hub](https://huggingface.co/meta-llama/Llama-2-70b-hf), then run `huggingface-cli login` in the terminal before starting the web app. If you don't want Llama 2, just remove the `meta-llama` repositories from [config.py](https://github.com/petals-infra/chat.petals.dev/blob/main/config.py#L17).
+🦙 **Want to serve Llama 2?** Request access to its weights at the ♾️ [Meta AI website](https://ai.meta.com/resources/models-and-libraries/llama-downloads/) and 🤗 [Model Hub](https://huggingface.co/meta-llama/Llama-2-70b-hf), then run `huggingface-cli login` in the terminal before starting the web app. If you don't want Llama 2, just remove the `meta-llama` models from [config.py](https://github.com/petals-infra/chat.petals.dev/blob/main/config.py).
 
 🦄 **Deploying with Gunicorn.** In production, we recommend using gunicorn instead of the Flask dev server:
 
@@ -110,7 +110,8 @@ The requests must follow this protocol:
 
 The first request must be of type **open_inference_session** and include these parameters:
 
-- **model** (str) - Model name (one of models defined in [config.py](https://github.com/petals-infra/chat.petals.dev/blob/main/config.py)).
+- **model** (str) - Model repository for one of the models defined in [config.py](https://github.com/petals-infra/chat.petals.dev/blob/main/config.py).
+    If you load a model with an adapter, use the adapter repository here instead.
 - **max_length** (int) - Max length of generated text (including prefix and intermediate inputs) in tokens.
 
 Notes:
@@ -161,7 +162,8 @@ Response (one or multiple):
 
 Parameters:
 
-- **model** (str) - Model name (one of models defined in [config.py](https://github.com/petals-infra/chat.petals.dev/blob/main/config.py)).
+- **model** (str) - Model repository for one of the models defined in [config.py](https://github.com/petals-infra/chat.petals.dev/blob/main/config.py).
+    If you load a model with an adapter, use the adapter repository here instead.
 - **inputs** (str, optional) - New user inputs. May be omitted if you continue generation in an inference session (see below).
 - **max_length** (int) - Max length of generated text (including prefix) in tokens.
 - **max_new_tokens** (int) - Max number of newly generated tokens (excluding prefix).

--- a/app.py
+++ b/app.py
@@ -20,9 +20,9 @@ sock = Sock(app)
 
 @app.route("/")
 def main_page():
-    default_family = list(config.MODELS.values())[0]
+    default_family = list(config.MODEL_FAMILIES.values())[0]
     default_model = list(default_family)[0]
-    return render_template("index.html", default_model=default_model, models=config.MODELS)
+    return render_template("index.html", default_model=default_model, model_families=config.MODEL_FAMILIES)
 
 
 import http_api

--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+import dataclasses
+import json
+
 import hivemind
 from flask import Flask, render_template
 from flask_cors import CORS
@@ -22,7 +25,19 @@ sock = Sock(app)
 def main_page():
     default_family = list(config.MODEL_FAMILIES.values())[0]
     default_model = list(default_family)[0]
-    return render_template("index.html", default_model=default_model, model_families=config.MODEL_FAMILIES)
+
+    model_configs = {
+        model_config.backend.key: model_config
+        for family_models in config.MODEL_FAMILIES.values()
+        for model_config in family_models
+    }
+
+    return render_template(
+        "index.html",
+        default_model=default_model,
+        model_families=config.MODEL_FAMILIES,
+        model_config_json=json.dumps(model_configs, default=dataclasses.asdict),
+    )
 
 
 import http_api

--- a/app.py
+++ b/app.py
@@ -1,47 +1,28 @@
 import hivemind
-from flask import Flask
+from flask import Flask, render_template
 from flask_cors import CORS
 from flask_sock import Sock
-from transformers import AutoTokenizer
-
-from petals import AutoDistributedModelForCausalLM
 
 import config
-
+import utils
 
 logger = hivemind.get_logger(__file__)
 
-models = {}
-for model_info in config.MODELS:
-    logger.info(f"Loading tokenizer for {model_info.repo}")
-    tokenizer = AutoTokenizer.from_pretrained(model_info.repo, add_bos_token=False, use_fast=False)
-
-    logger.info(f"Loading model {model_info.repo} with adapter {model_info.adapter} and dtype {config.TORCH_DTYPE}")
-    # We set use_fast=False since LlamaTokenizerFast takes a long time to init
-    model = AutoDistributedModelForCausalLM.from_pretrained(
-        model_info.repo,
-        active_adapter=model_info.adapter,
-        torch_dtype=config.TORCH_DTYPE,
-        initial_peers=config.INITIAL_PEERS,
-        max_retries=3,
-    )
-    model = model.to(config.DEVICE)
-
-    model_name = model_info.name
-    if model_name is None:  # Use default name based on model/repo repo
-        model_name = model_info.adapter if model_info.adapter is not None else model_info.repo
-    models[model_name] = model, tokenizer, model_info
+logger.info("Loading models")
+models = utils.load_models()
 
 logger.info("Starting Flask app")
 app = Flask(__name__)
 CORS(app)
-app.config['SOCK_SERVER_OPTIONS'] = {'ping_interval': 25}
+app.config["SOCK_SERVER_OPTIONS"] = {"ping_interval": 25}
 sock = Sock(app)
 
 
 @app.route("/")
 def main_page():
-    return app.send_static_file("index.html")
+    default_family = list(config.MODELS.values())[0]
+    default_model = list(default_family)[0]
+    return render_template("index.html", default_model=default_model, models=config.MODELS)
 
 
 import http_api

--- a/app.py
+++ b/app.py
@@ -1,13 +1,10 @@
-import dataclasses
-import json
-
 import hivemind
-from flask import Flask, render_template
+from flask import Flask
 from flask_cors import CORS
 from flask_sock import Sock
 
-import config
 import utils
+import views
 
 logger = hivemind.get_logger(__file__)
 
@@ -20,24 +17,13 @@ CORS(app)
 app.config["SOCK_SERVER_OPTIONS"] = {"ping_interval": 25}
 sock = Sock(app)
 
+logger.info("Pre-rendering index page")
+index_html = views.render_index(app)
+
 
 @app.route("/")
 def main_page():
-    default_family = list(config.MODEL_FAMILIES.values())[0]
-    default_model = list(default_family)[0]
-
-    model_configs = {
-        model_config.backend.key: model_config
-        for family_models in config.MODEL_FAMILIES.values()
-        for model_config in family_models
-    }
-
-    return render_template(
-        "index.html",
-        default_model=default_model,
-        model_families=config.MODEL_FAMILIES,
-        model_config_json=json.dumps(model_configs, default=dataclasses.asdict),
-    )
+    return index_html
 
 
 import http_api

--- a/config.py
+++ b/config.py
@@ -1,27 +1,57 @@
-from dataclasses import dataclass
-from typing import Optional
-
 import torch
-
 from petals.constants import PUBLIC_INITIAL_PEERS
 
+from data_structures import ModelInfo
 
-@dataclass
-class ModelInfo:
-    repo: str
-    adapter: Optional[str] = None
-    name: Optional[str] = None
-    public_api: bool = True
-
-
-MODELS = [
-    ModelInfo(repo="petals-team/StableBeluga2", name="stabilityai/StableBeluga2"),
-    ModelInfo(repo="meta-llama/Llama-2-70b-chat-hf"),
-    ModelInfo(repo="tiiuae/falcon-180B-chat", public_api=False),
-    ModelInfo(repo="huggyllama/llama-65b", adapter="timdettmers/guanaco-65b"),
-    ModelInfo(repo="huggyllama/llama-65b"),
-    ModelInfo(repo="bigscience/bloomz"),
-]
+MODELS = {
+    "Llama 2": [
+        ModelInfo(
+            name="Stable Beluga 2 (70B)",
+            model_card="https://huggingface.co/stabilityai/StableBeluga2",
+            license="https://huggingface.co/stabilityai/StableBeluga2/blob/main/LICENSE.txt",
+            repository="petals-team/StableBeluga2",
+            aliases=["stabilityai/StableBeluga2"],
+        ),
+        ModelInfo(
+            name="Llama 2 (70B-Chat)",
+            model_card="https://huggingface.co/meta-llama/Llama-2-70b-chat-hf",
+            license="https://bit.ly/llama2-license",
+            repository="meta-llama/Llama-2-70b-chat-hf",
+        ),
+    ],
+    "Falcon": [
+        ModelInfo(
+            name="Falcon 180B-Chat",
+            model_card="https://huggingface.co/tiiuae/falcon-180B-chat",
+            license="https://huggingface.co/spaces/tiiuae/falcon-180b-license/blob/main/LICENSE.txt",
+            repository="tiiuae/falcon-180B-chat",
+            public_api=False,
+        ),
+    ],
+    "Llama": [
+        ModelInfo(
+            name="Guanaco-65B",
+            model_card="https://huggingface.co/timdettmers/guanaco-65b",
+            license="https://huggingface.co/timdettmers/guanaco-65b",
+            repository="huggyllama/llama-65b",
+            adapter="timdettmers/guanaco-65b",
+        ),
+        ModelInfo(
+            name="Llama-65B",
+            model_card="https://github.com/facebookresearch/llama/blob/llama_v1/MODEL_CARD.md",
+            license="https://bit.ly/llama-license",
+            repository="huggyllama/llama-65b",
+        ),
+    ],
+    "BLOOM": [
+        ModelInfo(
+            name="BLOOMZ-176B",
+            model_card="https://huggingface.co/bigscience/bloomz",
+            license="https://bit.ly/bloom-license",
+            repository="bigscience/bloomz",
+        ),
+    ],
+}
 
 INITIAL_PEERS = PUBLIC_INITIAL_PEERS
 # Set this to a list of multiaddrs to connect to a private swarm instead of the public one, for example:
@@ -31,6 +61,7 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 try:
     from cpufeature import CPUFeature
+
     has_avx512 = CPUFeature["AVX512f"] and CPUFeature["OS_AVX512"]
 except ImportError:
     has_avx512 = False

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 import torch
 from petals.constants import PUBLIC_INITIAL_PEERS
 
-from data_structures import ModelBackendConfig, ModelChatConfig, ModelFrontendConfig, ModelConfig
+from data_structures import ModelBackendConfig, ModelChatConfig, ModelConfig, ModelFrontendConfig
 
 default_chat_config = ModelChatConfig(
     max_session_length=8192,

--- a/config.py
+++ b/config.py
@@ -1,54 +1,89 @@
 import torch
 from petals.constants import PUBLIC_INITIAL_PEERS
 
-from data_structures import ModelInfo
+from data_structures import ModelBackendConfig, ModelChatConfig, ModelFrontendConfig, ModelConfig
 
-MODELS = {
+default_chat_config = ModelChatConfig(
+    max_session_length=8192,
+    sep_token="###",
+    stop_token="###",
+    extra_stop_sequences=["</s>"],
+    generation_params=dict(do_sample=1, temperature=0.6, top_p=0.9),
+)
+
+MODEL_FAMILIES = {
     "Llama 2": [
-        ModelInfo(
-            name="Stable Beluga 2 (70B)",
-            model_card="https://huggingface.co/stabilityai/StableBeluga2",
-            license="https://huggingface.co/stabilityai/StableBeluga2/blob/main/LICENSE.txt",
-            repository="petals-team/StableBeluga2",
-            aliases=["stabilityai/StableBeluga2"],
+        ModelConfig(
+            ModelBackendConfig(repository="petals-team/StableBeluga2", aliases=["stabilityai/StableBeluga2"]),
+            ModelFrontendConfig(
+                name="Stable Beluga 2 (70B)",
+                model_card="https://huggingface.co/stabilityai/StableBeluga2",
+                license="https://huggingface.co/stabilityai/StableBeluga2/blob/main/LICENSE.txt",
+            ),
+            default_chat_config,
         ),
-        ModelInfo(
-            name="Llama 2 (70B-Chat)",
-            model_card="https://huggingface.co/meta-llama/Llama-2-70b-chat-hf",
-            license="https://bit.ly/llama2-license",
-            repository="meta-llama/Llama-2-70b-chat-hf",
+        ModelConfig(
+            ModelBackendConfig(repository="meta-llama/Llama-2-70b-chat-hf"),
+            ModelFrontendConfig(
+                name="Llama 2 (70B-Chat)",
+                model_card="https://huggingface.co/meta-llama/Llama-2-70b-chat-hf",
+                license="https://bit.ly/llama2-license",
+            ),
+            default_chat_config,
         ),
     ],
     "Falcon": [
-        ModelInfo(
-            name="Falcon 180B-Chat",
-            model_card="https://huggingface.co/tiiuae/falcon-180B-chat",
-            license="https://huggingface.co/spaces/tiiuae/falcon-180b-license/blob/main/LICENSE.txt",
-            repository="tiiuae/falcon-180B-chat",
-            public_api=False,
+        ModelConfig(
+            ModelBackendConfig(repository="tiiuae/falcon-180B-chat", public_api=False),
+            ModelFrontendConfig(
+                name="Falcon 180B-Chat",
+                model_card="https://huggingface.co/tiiuae/falcon-180B-chat",
+                license="https://huggingface.co/spaces/tiiuae/falcon-180b-license/blob/main/LICENSE.txt",
+            ),
+            ModelChatConfig(
+                max_session_length=8192,
+                sep_token="\n",
+                stop_token="\n",
+                extra_stop_sequences=["<|endoftext|>", "\nFalcon:", " Falcon:", "\nUser:", " User:", "###"],
+                generation_params=dict(do_sample=1, temperature=0.75, top_p=0.9, repetition_penalty=1.2),
+            ),
         ),
     ],
     "Llama": [
-        ModelInfo(
-            name="Guanaco-65B",
-            model_card="https://huggingface.co/timdettmers/guanaco-65b",
-            license="https://huggingface.co/timdettmers/guanaco-65b",
-            repository="huggyllama/llama-65b",
-            adapter="timdettmers/guanaco-65b",
+        ModelConfig(
+            ModelBackendConfig(repository="huggyllama/llama-65b", adapter="timdettmers/guanaco-65b"),
+            ModelFrontendConfig(
+                name="Guanaco-65B",
+                model_card="https://huggingface.co/timdettmers/guanaco-65b",
+                license="https://huggingface.co/timdettmers/guanaco-65b",
+            ),
+            default_chat_config,
         ),
-        ModelInfo(
-            name="Llama-65B",
-            model_card="https://github.com/facebookresearch/llama/blob/llama_v1/MODEL_CARD.md",
-            license="https://bit.ly/llama-license",
-            repository="huggyllama/llama-65b",
+        ModelConfig(
+            ModelBackendConfig(repository="huggyllama/llama-65b"),
+            ModelFrontendConfig(
+                name="Llama-65B",
+                model_card="https://github.com/facebookresearch/llama/blob/llama_v1/MODEL_CARD.md",
+                license="https://bit.ly/llama-license",
+            ),
+            default_chat_config,
         ),
     ],
     "BLOOM": [
-        ModelInfo(
-            name="BLOOMZ-176B",
-            model_card="https://huggingface.co/bigscience/bloomz",
-            license="https://bit.ly/bloom-license",
-            repository="bigscience/bloomz",
+        ModelConfig(
+            ModelBackendConfig(repository="bigscience/bloomz"),
+            ModelFrontendConfig(
+                name="BLOOMZ-176B",
+                model_card="https://huggingface.co/bigscience/bloomz",
+                license="https://bit.ly/bloom-license",
+            ),
+            ModelChatConfig(
+                max_session_length=2048,
+                sep_token="\n\n",
+                stop_token="</s>",
+                extra_stop_sequences=["\n\nHuman"],
+                generation_params=default_chat_config.generation_params,
+            ),
         ),
     ],
 }

--- a/config.py
+++ b/config.py
@@ -109,4 +109,3 @@ else:
     TORCH_DTYPE = torch.float32  # You can use bfloat16 in this case too, but it will be slow
 
 STEP_TIMEOUT = 5 * 60
-MAX_SESSIONS = 50  # Has effect only for API v1 (HTTP-based)

--- a/data_structures.py
+++ b/data_structures.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+
+@dataclass
+class ModelInfo:
+    repository: str
+    name: str
+    model_card: str
+    license: str
+
+    adapter: Optional[str] = None
+    aliases: Sequence[str] = ()
+    public_api: bool = True
+
+    @property
+    def key(self) -> str:
+        return self.repository if self.adapter is None else self.adapter

--- a/data_structures.py
+++ b/data_structures.py
@@ -3,12 +3,8 @@ from typing import Optional, Sequence
 
 
 @dataclass
-class ModelInfo:
+class ModelBackendConfig:
     repository: str
-    name: str
-    model_card: str
-    license: str
-
     adapter: Optional[str] = None
     aliases: Sequence[str] = ()
     public_api: bool = True
@@ -16,3 +12,26 @@ class ModelInfo:
     @property
     def key(self) -> str:
         return self.repository if self.adapter is None else self.adapter
+
+
+@dataclass
+class ModelFrontendConfig:
+    name: str
+    model_card: str
+    license: str
+
+
+@dataclass
+class ModelChatConfig:
+    max_session_length: int
+    sep_token: str
+    stop_token: str
+    extra_stop_sequences: str
+    generation_params: dict
+
+
+@dataclass
+class ModelConfig:
+    backend: ModelBackendConfig
+    frontend: ModelFrontendConfig
+    chat: ModelChatConfig

--- a/http_api.py
+++ b/http_api.py
@@ -24,8 +24,8 @@ def http_api_generate():
         max_new_tokens = get_typed_arg("max_new_tokens", int)
         logger.info(f"generate(), {model_name=}, {inputs=}")
 
-        model, tokenizer, model_info = models[model_name]
-        if not model_info.public_api:
+        model, tokenizer, backend_config = models[model_name]
+        if not backend_config.public_api:
             raise ValueError(f"We do not provide public API for {model_name} due to license restrictions")
 
         if inputs is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 120
+required-version = "22.3.0"
+
+[tool.isort]
+profile = "black"
+line_length = 120
+combine_as_imports = true
+combine_star = true
+known_local_folder = ["tests", "cli"]

--- a/static/chat.js
+++ b/static/chat.js
@@ -7,7 +7,7 @@ const models = {
     stopToken: "\n",
     extraStopSequences: ["<|endoftext|>", "\nFalcon:", " Falcon:", "\nUser:", " User:", "###"],
   },
-  "stabilityai/StableBeluga2": {
+  "petals-team/StableBeluga2": {
     modelCard: "https://huggingface.co/stabilityai/StableBeluga2",
     license: "https://huggingface.co/stabilityai/StableBeluga2/blob/main/LICENSE.txt",
     maxSessionLength: 8192,

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,10 +25,10 @@
       <div class="welcome mb-4">
         <div>
           <b>Welcome!</b> This is a demo app running
-          <a target="_blank" class="model-name" href="{{ default_model.model_card }}">{{ default_model.name }}</a>
+          <a target="_blank" class="model-name" href="{{ default_model.frontend.model_card }}">{{ default_model.frontend.name }}</a>
           over the <a target="_blank" href="https://petals.dev">Petals</a> network.
           Please follow the model's
-          <a target="_blank" class="license-link" href="{{ default_model.license }}">terms of use</a>
+          <a target="_blank" class="license-link" href="{{ default_model.frontend.license }}">terms of use</a>
           and do not enter sensitive data.
           The chat history is recorded.
         </div>
@@ -36,7 +36,7 @@
           <div class="mt-2">
             <label class="group-label">Family:</label>
             <div class="btn-group family-selector" role="group">
-              {% for family in models.keys() %}
+              {% for family in model_families.keys() %}
               {% set family_id = family.lower().replace(" ", "-") %}
               <input type="radio" class="btn-check" name="family" value="{{ family_id }}" id="family-{{ family_id }}"
                   {% if loop.first %}checked{% endif %}>
@@ -46,16 +46,16 @@
           </div>
           <div class="mt-2">
             <label class="group-label">Model:</label>
-            {% for family, family_models in models.items() %}
+            {% for family, family_models in model_families.items() %}
             {% set family_id = family.lower().replace(" ", "-") %}
             {% set family_loop = loop %}
             <div class="model-selector btn-group" role="group" data-family="{{ family_id }}"
                 {% if not loop.first %}style="display: none;"{% endif %}>
               {% for model in family_models %}
-              {% set model_id = model.key.lower().replace("/", "-") %}
-              <input type="radio" class="btn-check" name="model" value="{{ model.key }}" id="{{ model_id }}"
+              {% set model_id = model.backend.key.lower().replace("/", "-") %}
+              <input type="radio" class="btn-check" name="model" value="{{ model.backend.key }}" id="{{ model_id }}"
                   {% if family_loop.first and loop.first %}checked{% endif %}>
-              <label class="btn btn-outline-primary" for="{{ model_id }}">{{ model.name }}</label>
+              <label class="btn btn-outline-primary" for="{{ model_id }}">{{ model.frontend.name }}</label>
               {% endfor %}
             </div>
             {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -88,7 +88,12 @@
 </main>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" crossorigin="anonymous"></script>
     <script src="./static/autosize.min.js"></script>
-    <script src="./static/chat.js?v=17"></script>
+
+    <script>
+      const modelConfigs = {{ model_config_json|safe }};
+      const defaultModel = {{ default_model.backend.key|tojson|safe }};
+    </script>
+    <script src="./static/chat.js?v=18"></script>
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LENBCEYH86"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,10 +25,10 @@
       <div class="welcome mb-4">
         <div>
           <b>Welcome!</b> This is a demo app running
-          <a target="_blank" class="model-name" href="https://huggingface.co/stabilityai/StableBeluga2">Stable Beluga 2 (70B)</a>
+          <a target="_blank" class="model-name" href="{{ default_model.model_card }}">{{ default_model.name }}</a>
           over the <a target="_blank" href="https://petals.dev">Petals</a> network.
           Please follow the model's
-          <a target="_blank" class="license-link" href="https://huggingface.co/stabilityai/StableBeluga2/blob/main/LICENSE.txt">terms of use</a>
+          <a target="_blank" class="license-link" href="{{ default_model.license }}">terms of use</a>
           and do not enter sensitive data.
           The chat history is recorded.
         </div>
@@ -36,38 +36,29 @@
           <div class="mt-2">
             <label class="group-label">Family:</label>
             <div class="btn-group family-selector" role="group">
-              <input type="radio" class="btn-check" name="family" value="llama-2" id="family-llama-2" checked>
-              <label class="btn btn-outline-primary" for="family-llama-2">Llama 2</label>
-              <input type="radio" class="btn-check" name="family" value="falcon" id="family-falcon">
-              <label class="btn btn-outline-primary" for="family-falcon">Falcon</label>
-              <input type="radio" class="btn-check" name="family" value="llama" id="family-llama">
-              <label class="btn btn-outline-primary" for="family-llama">Llama</label>
-              <input type="radio" class="btn-check" name="family" value="bloom" id="family-bloom">
-              <label class="btn btn-outline-primary" for="family-bloom">BLOOM</label>
+              {% for family in models.keys() %}
+              {% set family_id = family.lower().replace(" ", "-") %}
+              <input type="radio" class="btn-check" name="family" value="{{ family_id }}" id="family-{{ family_id }}"
+                  {% if loop.first %}checked{% endif %}>
+              <label class="btn btn-outline-primary" for="family-{{ family_id }}">{{ family }}</label>
+              {% endfor %}
             </div>
           </div>
           <div class="mt-2">
             <label class="group-label">Model:</label>
-            <div class="model-selector btn-group" role="group" data-family="llama-2">
-              <input type="radio" class="btn-check" name="model" value="stabilityai/StableBeluga2" id="stablebeluga2" checked>
-              <label class="btn btn-outline-primary" for="stablebeluga2">Stable Beluga 2 (70B)</label>
-              <input type="radio" class="btn-check" name="model" value="meta-llama/Llama-2-70b-chat-hf" id="meta-llama-2-70b-chat-hf">
-              <label class="btn btn-outline-primary" for="meta-llama-2-70b-chat-hf">Llama 2 (70B-chat)</label>
+            {% for family, family_models in models.items() %}
+            {% set family_id = family.lower().replace(" ", "-") %}
+            {% set family_loop = loop %}
+            <div class="model-selector btn-group" role="group" data-family="{{ family_id }}"
+                {% if not loop.first %}style="display: none;"{% endif %}>
+              {% for model in family_models %}
+              {% set model_id = model.key.lower().replace("/", "-") %}
+              <input type="radio" class="btn-check" name="model" value="{{ model.key }}" id="{{ model_id }}"
+                  {% if family_loop.first and loop.first %}checked{% endif %}>
+              <label class="btn btn-outline-primary" for="{{ model_id }}">{{ model.name }}</label>
+              {% endfor %}
             </div>
-            <div class="model-selector btn-group" role="group" data-family="falcon" style="display: none;">
-              <input type="radio" class="btn-check" name="model" value="tiiuae/falcon-180B-chat" id="falcon-180B-chat">
-              <label class="btn btn-outline-primary" for="falcon-180B-chat">Falcon 180B-Chat</label>
-            </div>
-            <div class="model-selector btn-group" role="group" data-family="llama" style="display: none;">
-              <input type="radio" class="btn-check" name="model" value="timdettmers/guanaco-65b" id="model-guanaco-65b">
-              <label class="btn btn-outline-primary" for="model-guanaco-65b">Guanaco-65B</label>
-              <input type="radio" class="btn-check" name="model" value="huggyllama/llama-65b" id="model-llama-65b-hf">
-              <label class="btn btn-outline-primary" for="model-llama-65b-hf">Llama-65B</label>
-            </div>
-            <div class="model-selector btn-group" role="group" data-family="bloom" style="display: none;">
-              <input type="radio" class="btn-check" name="model" value="bigscience/bloomz" id="model-bloomz">
-              <label class="btn btn-outline-primary" for="model-bloomz">BLOOMZ-176B</label>
-            </div>
+            {% endfor %}
           </div>
         </form>
       </div>
@@ -88,7 +79,6 @@
       </p>
 
       <p class="acknowledgements mt-5 pt-3">
-        <!-- <a class="show-few-shot" href="#">Few-shot mode</a><br> -->
         <b>Shift+Enter</b> inserts newlines.<br>
         See source code and API docs on <a target="_blank" href="https://github.com/petals-infra/chat.petals.dev">GitHub</a>.<br>
         We do not provide API for Falcon-180B due to license restrictions.

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,42 @@
-from typing import List, Union
+from typing import Dict, List, Tuple, Union
 
+import hivemind
 import torch
-from transformers import PreTrainedTokenizerBase
+from petals import AutoDistributedModelForCausalLM
+from transformers import AutoTokenizer, PreTrainedModel, PreTrainedTokenizer
+
+import config
+from data_structures import ModelInfo
+
+logger = hivemind.get_logger(__file__)
 
 
-def safe_decode(tokenizer: PreTrainedTokenizerBase, outputs: Union[torch.Tensor, List[int]]) -> str:
+def load_models() -> Dict[str, Tuple[PreTrainedModel, PreTrainedTokenizer, ModelInfo]]:
+    models = {}
+    for family in config.MODELS.values():
+        for model_info in family:
+            logger.info(f"Loading tokenizer for {model_info.repository}")
+            tokenizer = AutoTokenizer.from_pretrained(model_info.repository, add_bos_token=False, use_fast=False)
+
+            logger.info(
+                f"Loading model {model_info.repository} with adapter {model_info.adapter} in {config.TORCH_DTYPE}"
+            )
+            # We set use_fast=False since LlamaTokenizerFast takes a long time to init
+            model = AutoDistributedModelForCausalLM.from_pretrained(
+                model_info.repository,
+                active_adapter=model_info.adapter,
+                torch_dtype=config.TORCH_DTYPE,
+                initial_peers=config.INITIAL_PEERS,
+                max_retries=3,
+            )
+            model = model.to(config.DEVICE)
+
+            for key in [model_info.key] + list(model_info.aliases):
+                models[key] = model, tokenizer, model_info
+    return models
+
+
+def safe_decode(tokenizer: PreTrainedTokenizer, outputs: Union[torch.Tensor, List[int]]) -> str:
     # Workaround to make SentencePiece .decode() keep leading spaces in a token
     fake_token = tokenizer("^")["input_ids"][0]
     outputs = outputs.tolist() if isinstance(outputs, torch.Tensor) else outputs

--- a/views.py
+++ b/views.py
@@ -1,0 +1,25 @@
+import dataclasses
+import json
+
+from flask import Flask, render_template
+
+import config
+
+
+def render_index(app: Flask) -> str:
+    default_family = list(config.MODEL_FAMILIES.values())[0]
+    default_model = list(default_family)[0]
+
+    model_configs = {
+        model_config.backend.key: model_config
+        for family_models in config.MODEL_FAMILIES.values()
+        for model_config in family_models
+    }
+
+    with app.app_context():
+        return render_template(
+            "index.html",
+            default_model=default_model,
+            model_families=config.MODEL_FAMILIES,
+            model_config_json=json.dumps(model_configs, default=dataclasses.asdict),
+        )

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -21,8 +21,8 @@ def ws_api_generate(ws):
         max_length = request["max_length"]
         logger.info(f"ws.generate.open(), {model_name=}, {max_length=}, {http_request.origin=}")
 
-        model, tokenizer, model_info = models[model_name]
-        if not model_info.public_api and http_request.origin != f"{http_request.scheme}://{http_request.host}":
+        model, tokenizer, backend_config = models[model_name]
+        if not backend_config.public_api and http_request.origin != f"{http_request.scheme}://{http_request.host}":
             raise ValueError(f"We do not provide public API for {model_name} due to license restrictions")
 
         with model.inference_session(max_length=max_length) as session:

--- a/websocket_api.py
+++ b/websocket_api.py
@@ -6,7 +6,7 @@ import hivemind
 from flask import request as http_request
 
 import config
-from app import sock, models
+from app import models, sock
 from utils import safe_decode
 
 logger = hivemind.get_logger(__file__)
@@ -44,10 +44,10 @@ def ws_api_generate(ws):
                 extra_stop_sequences = request.get("extra_stop_sequences")
                 if extra_stop_sequences is not None:
                     cont_token = tokenizer(stop_sequence, return_tensors="pt")["input_ids"].to(config.DEVICE)
-                    assert cont_token.shape == (1, 1), \
-                        "extra_stop_sequences require stop_sequence length to be exactly 1 token"
+                    if cont_token.shape != (1, 1):
+                        raise ValueError("extra_stop_sequences require stop_sequence length to be exactly 1 token")
 
-                all_outputs = ''
+                all_outputs = ""
                 delta_q = []
                 stop = False
                 while not stop:
@@ -67,13 +67,15 @@ def ws_api_generate(ws):
                     inputs = None  # Inputs are passed only for the 1st token of the bot's response
                     n_input_tokens = 0
                     combined = all_outputs + outputs
-                    stop = stop_sequence is None or ("falcon-180B" not in model_name and combined.endswith(stop_sequence))
+                    stop = stop_sequence is None or (
+                        "falcon-180B" not in model_name and combined.endswith(stop_sequence)
+                    )
                     if extra_stop_sequences is not None:
                         for seq in extra_stop_sequences:
                             if combined.endswith(seq):
                                 stop = True
                                 session.last_token_id = cont_token
-                    if not stop and outputs[-10:].find(u'\ufffd') > -1:
+                    if not stop and outputs[-10:].find("\ufffd") > -1:
                         # If there's a replacement character, keep getting more tokens
                         # until we can decode properly
                         delta_q = delta_q + delta


### PR DESCRIPTION
Before this PR, users needed to change all of `config.py`, `chat.js`, and `index.html` in non-trivial ways to add or remove some of served models. Now, it's enough to change `config.py` only in a straightforward way.