### PR TITLE
support specifying initial peers with an env

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,5 @@
 import torch
-from petals.constants import PUBLIC_INITIAL_PEERS
+import os
 
 from data_structures import ModelBackendConfig, ModelChatConfig, ModelConfig, ModelFrontendConfig
 
@@ -88,9 +88,13 @@ MODEL_FAMILIES = {
     # ],
 }
 
-INITIAL_PEERS = PUBLIC_INITIAL_PEERS
-# Set this to a list of multiaddrs to connect to a private swarm instead of the public one, for example:
-# INITIAL_PEERS = ['/ip4/10.1.2.3/tcp/31234/p2p/QmcXhze98AcgGQDDYna23s4Jho96n8wkwLJv78vxtFNq44']
+
+initial_peers = [peer for peer in os.environ.get("INITIAL_PEERS", "").split(" ") if peer]
+if initial_peers:
+    INITIAL_PEERS = initial_peers
+else:
+    from petals.constants import PUBLIC_INITIAL_PEERS
+    INITIAL_PEERS = PUBLIC_INITIAL_PEERS
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 


### PR DESCRIPTION
space separated seems to be the convention in these projects